### PR TITLE
Fix for staff info - 'name' & staff's kin 'name'-draft - prev comment (d...

### DIFF
--- a/app/models/kin.rb
+++ b/app/models/kin.rb
@@ -1,7 +1,14 @@
 class Kin < ActiveRecord::Base
+  before_save  :titleize_name
+
+  def titleize_name
+    self.name = name.titleize
+  end
   belongs_to :staff
   belongs_to :student
-  
+  validates_numericality_of :mykadno, :allow_blank => true
+  validates_length_of       :mykadno, :is =>12, :allow_blank => true
+  validates_format_of :name, :with => /^[a-zA-Z'`\/\. ]+$/, :message => I18n.t('activerecord.errors.messages.illegal_char') #add unwanted chars between bracket
   KTYPE = [
           #  Displayed       stored in db
           [ "Isteri",1 ],

--- a/app/models/staff.rb
+++ b/app/models/staff.rb
@@ -19,7 +19,7 @@ class Staff < ActiveRecord::Base
   validates_length_of       :icno, :is =>12
   validates_presence_of     :icno, :name, :coemail, :code, :appointdt #appointment date must exist be4 can apply leave
   validates_uniqueness_of   :icno, :fileno, :coemail, :code
-  validates_format_of       :name, :with => /^[a-zA-Z'` ]+$/, :message => "contains illegal characters" #add unwanted chars between bracket
+  validates_format_of       :name, :with => /^[a-zA-Z'`\/\. ]+$/, :message => I18n.t('activerecord.errors.messages.illegal_char') #add unwanted chars between bracket
   validates_presence_of     :cobirthdt, :addr, :poskod_id, :staffgrade_id, :statecd, :country_cd, :fileno
   #validates_length_of      :cooftelno, :is =>10
   #validates_length_of      :cooftelext, :is =>5
@@ -204,13 +204,14 @@ class Staff < ActiveRecord::Base
   accepts_nested_attributes_for :qualifications, :allow_destroy => true, :reject_if => lambda { |a| a[:level_id].blank? }
   
   has_many :loans, :dependent => :destroy
-  accepts_nested_attributes_for :loans, :reject_if => lambda { |a| a[:ltype].blank? }
+  accepts_nested_attributes_for :loans, :allow_destroy => true,:reject_if => lambda { |a| a[:ltype].blank? }
 
   has_many :kins, :dependent => :destroy
-  accepts_nested_attributes_for :kins, :reject_if => lambda { |a| a[:kintype_id].blank? }
+  accepts_nested_attributes_for :kins, :allow_destroy => true, :reject_if => lambda { |a| a[:kintype_id].blank? }
+  validates_associated :kins
   
   has_many :bankaccounts, :dependent => :destroy
-  accepts_nested_attributes_for :bankaccounts, :reject_if => lambda { |a| a[:account_no].blank? }
+  accepts_nested_attributes_for :bankaccounts,:allow_destroy => true, :reject_if => lambda { |a| a[:account_no].blank? }
   
  
      

--- a/app/views/staffs/_form.html.erb
+++ b/app/views/staffs/_form.html.erb
@@ -224,7 +224,7 @@
 		<% f.fields_for :qualifications do |builder| %>
 			<%= render 'qualification_fields', :f => builder %>
 		<% end %>
-		<p><%= link_to_add_fields image_tag("add.png", :border => 0, :title => 'Add Q'), f, :qualifications %> - Add More </p>
+		<p><%= link_to_add_fields image_tag("add.png", :border => 0, :title => t('addmore')), f, :qualifications %> - <%= t 'addmore' %> </p>
 	</div>
 	
 	<div>
@@ -244,7 +244,7 @@
 		<% f.fields_for :loans do |builder| %>
 			<p><%= render 'loan_fields', :f => builder %></p>
 		<% end %><BR>
-		<p><%= link_to_add_fields image_tag("add.png", :border => 0, :title => 'Add Q'), f, :loans %> - Add More </p>
+		<p><%= link_to_add_fields image_tag("add.png", :border => 0, :title => t('addmore')), f, :loans %> - <%= t 'addmore' %> </p>
 	</div>
 
 
@@ -289,7 +289,7 @@
 			<%= render 'kin_fields', :f => builder %>
 		<% end %>
 		<HR>
-		<p><%= link_to_add_fields image_tag("add.png", :border => 0, :title => 'Add More'), f, :kins %> - Add More </p>
+		<p><%= link_to_add_fields image_tag("add.png", :border => 0, :title => t('addmore')), f, :kins %> - <%= t 'addmore' %> </p>
 		
 	</div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -44,6 +44,12 @@ en:
               staffgrade_id: "Staff Grade"
               statecd: "State of Birth"
               country_cd: "Nationality"
+              kins:
+                 one: Maklumat Waris Terdekat
+                 other: Maklumat Waris Terdekat
+          kin:
+              name: Nama Waris
+              mykadno: MyKad No
           position:
               code: "Position Code"
           leaveforstaff:
@@ -87,6 +93,8 @@ en:
               not_a_number: "is not number"
               too_short: "is too short (minimum is {{count}} characters)"
               taken: "has already been taken"
+              illegal_char: contains illegal characters
+              invalid: invalid
 
   icms: 
     login:  Log In

--- a/config/locales/ms_MY.yml
+++ b/config/locales/ms_MY.yml
@@ -25,6 +25,7 @@ ms_MY:
             disposal: "Pembuangan"
             assetloss: "Asset Loss"
             librarytransaction: "Transaksi Buku"
+            kin: WARIS
         attributes:
             staff:
               icno: "No MyKad"
@@ -40,6 +41,12 @@ ms_MY:
               staffgrade_id: "Gred Staf"
               statecd: "Tempat Lahir"
               country_cd: "Kewarganegaraan"
+              kins:
+                one: Maklumat Waris Terdekat
+                other: Maklumat Waris Terdekat
+            kin:
+              name: Nama Waris
+              mykadno: "No.MyKad Waris"
             attendance:
               staff_id: "Nama Kakitangan"
             position:
@@ -75,8 +82,10 @@ ms_MY:
             blank: "tidak boleh dikosongkan"
             not_a_number: "ialah bukan nombor"
             too_short: "ialah sangat pendek (minimum ialah {{count}} huruf)"
-            wrong_length: "panjang salah (mesti {{count}} huruf)"
+            wrong_length: " - panjang salah (mesti {{count}} huruf)"
             taken: "sudah diambil"
+            illegal_char: mengandungi aksara yang tidak sah
+            invalid: adalah tidak sah
   icms: 
     login:  Daftar Masuk
     logout: Keluar


### PR DESCRIPTION
...ata dictionary) not yet applied

Fixes done based on previous comment which include fixes for staff name field :
1) A/p & A/l (now accept 'slash' character in name field)
2) Also accept  (use of ' in name field) - eg Saa'diah
3) Also accept (use of . in name field) - eg St. 

Also include validation (above items 1-3 also applied) & titleize for nested form(KIN)of staff. 
